### PR TITLE
Windows compatibility for fs tests

### DIFF
--- a/src/utils/fs.spec.js
+++ b/src/utils/fs.spec.js
@@ -1,4 +1,5 @@
 const fs = require('fs')
+const path = require('path')
 
 jest.mock('fs')
 jest.mock('util', () => ({
@@ -83,7 +84,6 @@ describe('findUpwardsFile()', () => {
   })
 
   it('looks for file in the supplied directory', async () => {
-    const path = jest.requireActual('path')
     const { findUpwardsFile } = jest.requireActual('./fs')
 
     fs.access.mockReturnValue()
@@ -108,7 +108,6 @@ describe('findUpwardsFile()', () => {
     cwdSpy.mockRestore()
   })
   it('returns an absolute path when matching file is found', async () => {
-    const path = jest.requireActual('path')
     const { findUpwardsFile } = jest.requireActual('./fs')
 
     fs.access.mockResolvedValue()

--- a/src/utils/fs.spec.js
+++ b/src/utils/fs.spec.js
@@ -83,6 +83,7 @@ describe('findUpwardsFile()', () => {
   })
 
   it('looks for file in the supplied directory', async () => {
+    const path = jest.requireActual('path')
     const { findUpwardsFile } = jest.requireActual('./fs')
 
     fs.access.mockReturnValue()
@@ -90,7 +91,7 @@ describe('findUpwardsFile()', () => {
     const targetFile = await findUpwardsFile(filename, directory)
 
     expect(fs.access).toHaveBeenCalledTimes(1)
-    expect(targetFile).toBe('/home/test/test.file')
+    expect(targetFile).toBe(path.normalize('/home/test/test.file'))
   })
   it('defaults to process.cwd()', async () => {
     const { findUpwardsFile } = jest.requireActual('./fs')
@@ -107,13 +108,14 @@ describe('findUpwardsFile()', () => {
     cwdSpy.mockRestore()
   })
   it('returns an absolute path when matching file is found', async () => {
+    const path = jest.requireActual('path')
     const { findUpwardsFile } = jest.requireActual('./fs')
 
     fs.access.mockResolvedValue()
 
     const targetFile = await findUpwardsFile(filename, directory)
 
-    expect(targetFile).toBe('/home/test/test.file')
+    expect(targetFile).toBe(path.normalize('/home/test/test.file'))
   })
   it('returns false when file cannot be found', async () => {
     const { findUpwardsFile } = jest.requireActual('./fs')


### PR DESCRIPTION
As I mentioned in a [previous comment](https://github.com/Sleavely/exodus-migrations/pull/11#issuecomment-623328669), the expectations for `src/utils/fs.spec.js` rely on Unix-style paths which causes them to fail when running tests in a Windows environment.

This PR addresses the issue by first letting `path` normalize the path to the correct OS format.