### PR TITLE
Moves run migrations loop to it's own function

### DIFF
--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -77,9 +77,6 @@ describe('create()', () => {
 })
 
 describe('migrate()', () => {
-  beforeEach(() => {
-    config.getConfig.mockResolvedValue({})
-  })
   it('builds context', async () => {
     const contextBuilder = jest.fn()
     config.getConfig.mockResolvedValueOnce({ context: contextBuilder })
@@ -87,5 +84,19 @@ describe('migrate()', () => {
     await main.migrate().catch(() => {})
 
     expect(contextBuilder).toHaveBeenCalled()
+  })
+
+  it('returns ran migrations and state after running migrations', async () => {
+    const fetchState = jest.fn()
+    fetchState.mockResolvedValue({})
+    config.getConfig.mockResolvedValueOnce({ fetchState })
+    const job = { title: 'test-job-pls-ignore' }
+    migrations.runPendingMigrations.mockResolvedValueOnce([job])
+
+    const { state, ranMigrations } = await main.migrate()
+
+    expect(migrations.runPendingMigrations).toHaveBeenCalledTimes(1)
+    expect(ranMigrations).toMatchObject([job])
+    expect(state).toMatchObject(state)
   })
 })

--- a/src/migrations.js
+++ b/src/migrations.js
@@ -35,6 +35,21 @@ exports.getPendingJobs = async () => {
   return pendingMigrations
 }
 
+exports.runPendingJobs = async () => {
+  const config = await getConfig()
+
+  const pendingJobs = await this.getPendingJobs()
+
+  if (pendingJobs.length) {
+    await config.beforeAll(pendingJobs)
+
+    for (const migrationJob of pendingJobs) {
+      await this.up(migrationJob)
+    }
+    await config.afterAll(pendingJobs)
+  }
+}
+
 exports.up = async (migrationJob) => {
   const config = await getConfig()
   const context = await config.context()


### PR DESCRIPTION
Just moved the logic into it's own function. Next - fix tests, then add more tests to test the logic in migrations.js