### PR TITLE
Save state for each successful migration

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -65,13 +65,16 @@ const action = cli.input[0]
         ora().info('No migrations to run.')
       }
     } catch (err) {
+      let currentFile
       for (let filename in spinners) {
         // find runnign ones and fail them.
-        if (spinners[filename].isSpinning) spinners[filename].fail()
+        if (spinners[filename].isSpinning) currentFile = filename
       }
+      spinners[currentFile].fail()
       console.error(err)
       ora('').warn()
-      ora('Migrations state was not saved - any jobs that succeeded will be run again next time.').warn()
+      ora(`"${currentFile}" encountered a problem. The error above might help.`).warn()
+      ora('Migrations that finished have been saved to history and will not run again.').warn()
       ora('').warn()
       process.exit(1)
     }

--- a/src/index.js
+++ b/src/index.js
@@ -50,14 +50,7 @@ exports.run = async () => {
     if (config.afterAll) await config.afterAll(pendingMigrations)
   }
 
-  // Store which migrations have been run, but clean absolute paths
   const state = await config.fetchState(context)
-  state.lastRan = (new Date()).toJSON()
-  state.history.forEach((job) => {
-    delete job.path
-  })
-  await config.storeState(state, context)
-
   return { state, ranMigrations: pendingMigrations }
 }
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -165,28 +165,4 @@ describe('run()', () => {
 
     expect(afterAll).not.toHaveBeenCalled()
   })
-
-  it('stores executed migrations to state', async () => {
-    const fetchState = jest.fn()
-    const storeState = jest.fn()
-    config.getConfig.mockResolvedValueOnce({ fetchState, storeState })
-    const job = {
-      title: 'Chief Migration Officer',
-    }
-    migrations.getPendingJobs.mockResolvedValueOnce([job])
-
-    // The migrations module would have appended our job to in-memory state by now
-    fetchState.mockResolvedValue({ history: [job] })
-
-    await main.run()
-
-    expect(storeState).toHaveBeenCalled()
-    expect(storeState.mock.calls[0][0]).toEqual({
-      // Looks like a date, talks like a date?
-      lastRan: expect.stringMatching(/^\d\d\d\d-\d\d-\d\dT\d\d/),
-      history: [
-        job,
-      ],
-    })
-  })
 })

--- a/src/migrations.js
+++ b/src/migrations.js
@@ -52,7 +52,12 @@ exports.up = async (migrationJob) => {
   migrationJob.finishedAt = (new Date()).toJSON()
   await config.afterEach(migrationJob)
 
+  // Store job in history, but strip absolute path
+  // since it's not relevant in distributed environments.
+  delete migrationJob.path
   state.history.push(migrationJob)
+  state.lastRan = migrationJob.finishedAt
+  await config.storeState(state, context)
 
   return state
 }

--- a/src/migrations.spec.js
+++ b/src/migrations.spec.js
@@ -1,4 +1,30 @@
 
+jest.doMock('./config')
+const config = require('./config')
+
+const migrations = require('./migrations')
+
+/**
+ * Prepares a module that can be require()'d by the application
+ */
+const createVirtualMigration = () => {
+  const job = {
+    path: `./exodus-test-suite/${Math.ceil(Math.random() * 1000)}/migration.js`,
+  }
+  const migrationModule = {
+    up: jest.fn(),
+    down: jest.fn(),
+  }
+  const exportsFactory = jest.fn(() => migrationModule)
+  jest.doMock(job.path, exportsFactory, { virtual: true })
+
+  return {
+    job,
+    migrationModule,
+    exportsFactory,
+  }
+}
+
 describe('getSampleMigration()', () => {
   it.todo('test')
 })
@@ -9,4 +35,33 @@ describe('getPendingJobs()', () => {
 
 describe('up()', () => {
   it.todo('test')
+
+  it('stores executed migrations to state', async () => {
+    const fetchState = jest.fn(async () => ({ history: [] }))
+    const storeState = jest.fn()
+    const context = jest.fn(() => ({}))
+    const beforeAfterHooks = jest.fn()
+    config.getConfig.mockResolvedValueOnce({
+      context,
+      fetchState,
+      storeState,
+      beforeEach: beforeAfterHooks,
+      afterEach: beforeAfterHooks,
+    })
+
+    const { job } = createVirtualMigration()
+
+    await migrations.up(job)
+
+    expect(storeState).toHaveBeenCalled()
+    expect(storeState.mock.calls[0][0]).toEqual({
+      // Looks like a date, talks like a date?
+      lastRan: expect.stringMatching(/^\d\d\d\d-\d\d-\d\dT\d\d/),
+      history: [
+        job,
+      ],
+    })
+  })
+
+  it.todo('doesnt store absolute file path prop to history')
 })


### PR DESCRIPTION
Changes behavior to store state for every individual migration. Increased I/O in favor of an accurate snapshot of the current state of migrations.