### PR TITLE
Rename run() to migrate()

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,11 @@ jobs:
 
       - run: node bin/cli.js create test-migration
 
-      - run: node bin/cli.js run
+      - run: node bin/cli.js migrate
 
       # And again to make sure it doesnt crash when queue is empty
+      - run: node bin/cli.js migrate
+
+      # Test backwards-compatible alias
+      # TODO: Remove in ^2.0.0
       - run: node bin/cli.js run

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ exodus --help
   Possible actions
     init              Adds a config file in your project directory
     create <name>     Creates a new file in your migrations dir
-    run               Runs all remaining migrations
+    migrate           Runs all remaining migrations
 
   Options
     --help

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -32,6 +32,7 @@ let action = cli.input[0]
   if (action === 'run') {
     // TODO: Remove in ^2.0.0
     action = 'migrate'
+    ora('The "run" command has been deprecated and will be removed in the next major version. Use "migrate" instead.').warn()
   }
 
   if (action === 'init') {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -14,7 +14,7 @@ Usage
 Possible actions
   init              Adds a config file in your project directory
   create <name>     Creates a new file in your migrations dir
-  run               Runs all remaining migrations
+  migrate           Runs all remaining migrations
 
 Options
   --help
@@ -26,9 +26,14 @@ ${self.homepage}
   flags: {},
 })
 
-const action = cli.input[0]
+let action = cli.input[0]
 
 ;(async () => {
+  if (action === 'run') {
+    // TODO: Remove in ^2.0.0
+    action = 'migrate'
+  }
+
   if (action === 'init') {
     const targetFile = `${Object.keys(self.bin)[0]}.config.js`
     const targetPath = path.join(process.cwd(), targetFile)
@@ -39,7 +44,7 @@ const action = cli.input[0]
     if (!name) throw new Error('No name supplied for "create" command.')
     const targetPath = await main.create(name)
     console.log(`Created migration in "${targetPath}`)
-  } else if (action === 'run') {
+  } else if (action === 'migrate') {
     // Wrap *Each() to print each migration.
     const config = await main.getConfig()
     const spinners = {}

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ exports.create = async (name) => {
 /**
  * Run all unprocessed migrations
  */
-exports.run = async () => {
+exports.migrate = async () => {
   // find the config
   const config = await getConfig()
 
@@ -60,6 +60,12 @@ exports.run = async () => {
 
   return { state, ranMigrations: pendingMigrations }
 }
+/**
+ * TODO: Remove in ^2.0.0
+ *
+ * @deprecated
+ */
+exports.run = this.migrate
 
 exports.rollback = async () => {}
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -76,7 +76,7 @@ describe('create()', () => {
   })
 })
 
-describe('run()', () => {
+describe('migrate()', () => {
   beforeEach(() => {
     config.getConfig.mockResolvedValue({})
   })
@@ -84,13 +84,13 @@ describe('run()', () => {
     const contextBuilder = jest.fn()
     config.getConfig.mockResolvedValueOnce({ context: contextBuilder })
 
-    await main.run().catch(() => {})
+    await main.migrate().catch(() => {})
 
     expect(contextBuilder).toHaveBeenCalled()
   })
 
   it('determines pending jobs from state history', async () => {
-    await main.run().catch(() => {})
+    await main.migrate().catch(() => {})
 
     expect(migrations.getPendingJobs).toHaveBeenCalled()
   })
@@ -104,7 +104,7 @@ describe('run()', () => {
     }
     migrations.getPendingJobs.mockResolvedValueOnce([job])
 
-    await main.run().catch(() => {})
+    await main.migrate().catch(() => {})
 
     expect(migrations.up).toHaveBeenCalledWith(job)
   })
@@ -117,7 +117,7 @@ describe('run()', () => {
     // Because fast computers are THE WORST
     migrations.up.mockReturnValue(Date.now() + 1)
 
-    await main.run().catch(() => {})
+    await main.migrate().catch(() => {})
 
     expect(beforeAll).toHaveBeenCalled()
     expect(migrations.up).toHaveBeenCalled()
@@ -136,7 +136,7 @@ describe('run()', () => {
     })
     migrations.getPendingJobs.mockResolvedValueOnce([{}])
 
-    await main.run().catch(() => {})
+    await main.migrate().catch(() => {})
 
     expect(migrations.up).toHaveBeenCalled()
     expect(afterAll).toHaveBeenCalled()
@@ -150,7 +150,7 @@ describe('run()', () => {
     // Pretend this isnt the DMV by using an empty queue
     migrations.getPendingJobs.mockResolvedValueOnce([])
 
-    await main.run().catch(() => {})
+    await main.migrate().catch(() => {})
 
     expect(beforeAll).not.toHaveBeenCalled()
   })
@@ -161,7 +161,7 @@ describe('run()', () => {
     // You're in luck; fast-track normally costs extra!
     migrations.getPendingJobs.mockResolvedValueOnce([])
 
-    await main.run().catch(() => {})
+    await main.migrate().catch(() => {})
 
     expect(afterAll).not.toHaveBeenCalled()
   })
@@ -178,7 +178,7 @@ describe('run()', () => {
     // The migrations module would have appended our job to in-memory state by now
     fetchState.mockResolvedValue({ history: [job] })
 
-    await main.run()
+    await main.migrate()
 
     expect(storeState).toHaveBeenCalled()
     expect(storeState.mock.calls[0][0]).toEqual({


### PR DESCRIPTION
Replaces references of `exodus run` with `exodus migrate` to stay in line with other migration frameworks. The term `migrate` is more descriptive and less ambiguous, since the program would technically also "run" a rollback.

`exodus run` remains as an alias but should be replaced in the next major version.