### PR TITLE
Abort "init" when config already exists

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -39,7 +39,12 @@ let action = cli.input[0]
     const targetFile = `${Object.keys(self.bin)[0]}.config.js`
     const targetPath = path.join(process.cwd(), targetFile)
     await main.init(targetPath)
-    console.log(`Created configuration in "${targetPath}"`)
+      .then(() => ora().succeed(`Created configuration in "${targetPath}"`))
+      .catch((err) => {
+        if (err.code !== 'INITEXISTS') throw err
+        ora().fail(err.message)
+        process.exit(1)
+      })
   } else if (action === 'create') {
     const name = cli.input[1]
     if (!name) throw new Error('No name supplied for "create" command.')

--- a/src/config.js
+++ b/src/config.js
@@ -6,14 +6,23 @@ exports.getSampleConfig = async () => {
   return fs.readFile(path.resolve(__dirname, './templates/config.js'), 'utf8')
 }
 
+exports.findConfig = async () => {
+  const configName = 'exodus.config.js'
+  const targetConfig = await fs.findUpwardsFile(configName)
+  if (!targetConfig) {
+    const err = new Error(`Could not find ${configName} in this or any parent directories.`)
+    err.code = 'NOCONFIG'
+    throw err
+  }
+  return targetConfig
+}
+
 let _config
 let _context
 let _state
 exports.getConfig = async () => {
   if (!_config) {
-    const configName = 'exodus.config.js'
-    const targetConfig = await fs.findUpwardsFile(configName)
-    if (!targetConfig) throw new Error(`Could not find ${configName} in this or any parent directories.`)
+    const targetConfig = await this.findConfig()
 
     const externalConfig = require(targetConfig)
     _config = {

--- a/src/config.spec.js
+++ b/src/config.spec.js
@@ -43,16 +43,36 @@ describe('getSampleConfig()', () => {
   })
 })
 
+describe('findConfig()', () => {
+  it('looks for config in current or parent directories', async () => {
+    await config.findConfig().catch(() => {})
+
+    expect(fs.findUpwardsFile).toHaveBeenCalledWith('exodus.config.js')
+  })
+  it('returns the path of the file it finds', async () => {
+    fs.findUpwardsFile.mockResolvedValueOnce('/yolo/swag')
+
+    await expect(config.findConfig()).resolves.toBe('/yolo/swag')
+  })
+  it('throws with code NOCONFIG if no file can be found', async () => {
+    fs.findUpwardsFile.mockResolvedValueOnce(false)
+
+    await expect(config.findConfig()).rejects.toThrow('not find exodus')
+  })
+})
+
 describe('getConfig()', () => {
-  it('finds config in current or parent directories', async () => {
-    expect.assertions(1)
+  it('uses findConfig() to locate the appropriate file', async () => {
+    const spy = jest.spyOn(config, 'findConfig')
     await config.getConfig()
       // Dont care if we fail down the line for this test
       .catch(() => {})
       .finally(() => {
         // Trust and outsource to findUpwardsFile
-        expect(fs.findUpwardsFile).toHaveBeenCalled()
+        expect(spy).toHaveBeenCalled()
       })
+    spy.mockReset()
+    spy.mockRestore()
   })
 
   it('merges with default settings', async () => {

--- a/src/config.spec.js
+++ b/src/config.spec.js
@@ -54,10 +54,17 @@ describe('findConfig()', () => {
 
     await expect(config.findConfig()).resolves.toBe('/yolo/swag')
   })
-  it('throws with code NOCONFIG if no file can be found', async () => {
-    fs.findUpwardsFile.mockResolvedValueOnce(false)
+  it('throws if no file can be found', async () => {
+    expect.assertions(3)
 
-    await expect(config.findConfig()).rejects.toThrow('not find exodus')
+    fs.findUpwardsFile.mockResolvedValueOnce(false)
+    await expect(config.findConfig()).rejects.toThrow()
+
+    fs.findUpwardsFile.mockResolvedValueOnce(false)
+    await config.findConfig().catch(err => {
+      expect(err.message).toInclude('not find exodus')
+      expect(err.code).toBe('NOCONFIG')
+    })
   })
 })
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,16 @@
-const { getConfig, getSampleConfig } = require('./config')
-const { getSampleMigration, runPendingMigrations } = require('./migrations')
-const { mkdir, writeFile } = require('./utils/fs')
+const {
+  findConfig,
+  getConfig,
+  getSampleConfig,
+} = require('./config')
+const {
+  getSampleMigration,
+  runPendingMigrations,
+} = require('./migrations')
+const {
+  mkdir,
+  writeFile,
+} = require('./utils/fs')
 const path = require('path')
 const slugify = require('slugify')
 
@@ -10,8 +20,18 @@ exports.getConfig = getConfig
  * Create a sample configuration in the supplied path
  */
 exports.init = async (targetPath) => {
+  const existingConfigPath = await findConfig()
+    .catch(err => {
+      if (err.code === 'NOCONFIG') return false
+      throw err
+    })
   const sampleConfig = await getSampleConfig()
-  await writeFile(targetPath, sampleConfig)
+  if (existingConfigPath) {
+    const err = new Error(`A configuration already exists in "${existingConfigPath}"`)
+    err.code = 'INITEXISTS'
+    throw err
+  }
+  return writeFile(targetPath, sampleConfig)
 }
 
 /**

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -32,11 +32,18 @@ it('can be loaded without throwing exceptions', () => {
 describe('init()', () => {
   it('writes a configtemplate to the supplied path', async () => {
     const targetPath = path.join(process.cwd(), 'exodus-init-test.js')
+    config.findConfig.mockRejectedValueOnce({ code: 'NOCONFIG' })
     config.getSampleConfig.mockResolvedValueOnce('Hello world')
 
     await main.init(targetPath)
 
     expect(fs.writeFile).toHaveBeenCalledWith(targetPath, 'Hello world')
+  })
+  it('throws if a configuration already exists', async () => {
+    const targetPath = path.join(process.cwd(), 'exodus-init-test.js')
+    config.findConfig.mockResolvedValueOnce('/interwebz/exodus.config.js')
+
+    await expect(main.init(targetPath)).rejects.toThrow('already exists')
   })
 })
 

--- a/src/utils/fs.js
+++ b/src/utils/fs.js
@@ -23,7 +23,7 @@ exports.findUpwardsFile = async (filename, directory = process.cwd()) => {
   const targetFile = path.join(parsedPath.dir, parsedPath.base)
   let fileExists = false
   try {
-    await exports.access(targetFile, 'utf8')
+    await this.access(targetFile, 'utf8')
     fileExists = true
   } catch (err) {
     if (err.code !== 'ENOENT') throw err
@@ -37,7 +37,7 @@ exports.findUpwardsFile = async (filename, directory = process.cwd()) => {
       return false
     } else {
       // Keep digging
-      return exports.findUpwardsFile(filename, path.dirname(directory))
+      return this.findUpwardsFile(filename, path.dirname(directory))
     }
   }
 }
@@ -50,7 +50,7 @@ exports.findUpwardsFile = async (filename, directory = process.cwd()) => {
  */
 exports.listDirectoryFiles = async (directoryPath) => {
   // Note: withFileTypes requires Node 10+
-  const dirItems = await exports.readDir(directoryPath, { withFileTypes: true })
+  const dirItems = await this.readDir(directoryPath, { withFileTypes: true })
 
   return dirItems
     .filter(item => !item.isDirectory())


### PR DESCRIPTION
This PR modifies the "init" command so that if any of the parent directories already have an exodus configuration, it will abort. Fixes #10 

![Terminal screenshot of behavior](https://i.imgur.com/FTzSosP.png)