### PR TITLE
Only consider .js files

### DIFF
--- a/src/migrations.js
+++ b/src/migrations.js
@@ -23,6 +23,7 @@ exports.getPendingJobs = async () => {
 
   const pendingMigrations = files
     .filter((filename) => {
+      if (!filename.endsWith('.js')) return false
       return !alreadyRanFiles.includes(filename)
     })
     .sort()


### PR DESCRIPTION
Relates to #28 - it's not a complete fix but it mitigates the problem, especially for `.csv`, `.json`, and `.gitkeep` files.